### PR TITLE
Add support for template variables

### DIFF
--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -75,7 +75,6 @@ export function run(templatesManager: TemplatesManager, args: any) {
                                 return;
                             }
                             fileContents = fileContents.replace(regex, value);
-                            console.log(fileContents, value);
                             resolve(fileContents);
                         });
                     });

--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -23,7 +23,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
     let targetFolder = args ? args.fsPath : vscode.workspace.rootPath;
 
     if (templates.length === 0) {
-        let optionGoToTemplates = <vscode.MessageItem>{
+        let optionGoToTemplates = <vscode.MessageItem> {
             title: "Open Templates Folder"
         };
 
@@ -50,7 +50,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
         }
 
         // ask for filename
-        let inputOptions = <vscode.InputBoxOptions>{
+        let inputOptions = <vscode.InputBoxOptions> {
             prompt: "Please enter the desired filename",
             value: selection,
         };
@@ -60,13 +60,13 @@ export function run(templatesManager: TemplatesManager, args: any) {
             const className = filename.replace(/\.[^/.]+$/, "");
             const expression = /#{(\w+)}/g;
             const resultsPromise = [];
-            let regexResult;
+            let regexResult = expression.exec(fileContents);
 
-            while (regexResult = expression.exec(fileContents)) {
+            while (regexResult) {
                 const variableName = regexResult[1];
-                const regex = new RegExp(`#{${variableName}}`, 'g');
+                const regex = new RegExp(`#{${variableName}}`, "g");
                 if (variableName !== "filename") {
-                    let variableInput = <vscode.InputBoxOptions>{
+                    let variableInput = <vscode.InputBoxOptions> {
                         prompt: `Please enter the desired value for "${variableName}"`
                     };
                     let variablePromise = new Promise((resolve, reject) => {
@@ -82,6 +82,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
                 } else {
                     fileContents = fileContents.replace(regex, className);
                 }
+                regexResult = expression.exec(fileContents);
             }
 
             Promise.all(resultsPromise).then(() => {
@@ -91,7 +92,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
                     }
                     vscode.window.showInformationMessage(filename + " created");
                 });
-            })
+            });
 
         });
     });

--- a/src/templatesManager.ts
+++ b/src/templatesManager.ts
@@ -3,7 +3,6 @@ import {WorkspaceConfiguration} from 'vscode';
 import fs = require('fs');
 import path = require('path');
 import os = require('os');
-
 /**
  * Main class to handle the logic of the File Templates
  * @export
@@ -37,8 +36,8 @@ export default class TemplatesManager {
      * @param filename The name of the template file.
      * @return Buffer
      */
-    public getTemplate(filename): Buffer {
-        return fs.readFileSync(path.join(this.getTemplatesDir(), filename));
+    public getTemplate(filename): string {
+        return fs.readFileSync(path.join(this.getTemplatesDir(), filename), 'utf8');
     }
 
     /**


### PR DESCRIPTION
The variable format inside the template would be:
`#{variableName}`

`#{filename}` is a preserved variable name which inserts the file name. IMO very useful for Class file etc.

For every other variable a input box opens and the desired value can be inserted.
an example class file would be:

```
import React, {Component} from 'react';
import {connect} from 'react-redux';

class #{filename} extends Component{
    render(){
        return (
            <div>#{testVariable}</div>
        );
    }
}
```

I had to add file encoding (utf8) to `getTemplate(filename)` to return a string instead of a buffer.

Appreciate your feedback. 😄 
