### PR TITLE
Bug fix - cannot create new template file with another name

### DIFF
--- a/src/commands/templateFromFileCommand.ts
+++ b/src/commands/templateFromFileCommand.ts
@@ -30,8 +30,13 @@ export function run(templatesManager: TemplatesManager, args: any) {
     };
 
     vscode.window.showInputBox(inputOptions).then(filename => {
+        if(!fileName) {
+            // user pressed escape, fileName is undefined
+            return ;
+        }
+
         let fileContents = fs.readFileSync(filePath);
-        let templateFile = path.join(templatesManager.getTemplatesDir(), path.basename(filePath));
+        let templateFile = path.join(templatesManager.getTemplatesDir(), filename);
 
         fs.writeFile(templateFile, fileContents, function (err) {
             if (err) {


### PR DESCRIPTION
Fix 2 errors in New Template from File command:
1. Pressing esc in prompt file name should do nothing now
2. Whatever you type in the new template file name prompt, it uses the original file name