### PR TITLE
Use the name the user supplied for the template.

### DIFF
--- a/src/commands/templateFromFileCommand.ts
+++ b/src/commands/templateFromFileCommand.ts
@@ -31,7 +31,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
 
     vscode.window.showInputBox(inputOptions).then(filename => {
         let fileContents = fs.readFileSync(filePath);
-        let templateFile = path.join(templatesManager.getTemplatesDir(), path.basename(filePath));
+        let templateFile = path.join(templatesManager.getTemplatesDir(), path.basename(filename));
 
         fs.writeFile(templateFile, fileContents, function (err) {
             if (err) {


### PR DESCRIPTION
When doing a "New Template from File" and changing the file name, the template saves with the original file name.

This PR fixes that.

![image](https://cloud.githubusercontent.com/assets/928403/24591403/1a89c818-17c6-11e7-9116-b40054308535.png)

![image](https://cloud.githubusercontent.com/assets/928403/24591412/371777b4-17c6-11e7-8efa-299bb495dfe4.png)


