### PR TITLE
Allow newly created template to be edited

### DIFF
--- a/src/commands/templateFromFileCommand.ts
+++ b/src/commands/templateFromFileCommand.ts
@@ -41,8 +41,8 @@ export function run(templatesManager: TemplatesManager, args: any) {
                     if (choice === "Yes") {
                         vscode.workspace.openTextDocument(templateFile).then((doc) => {
                             const editor = vscode.window.activeTextEditor;
-                            const column = editor.viewColumn;
-                            vscode.window.showTextDocument(doc, column);
+
+                            vscode.window.showTextDocument(doc, editor.viewColumn);
                         });
                     }
                 });

--- a/src/commands/templateFromFileCommand.ts
+++ b/src/commands/templateFromFileCommand.ts
@@ -37,7 +37,15 @@ export function run(templatesManager: TemplatesManager, args: any) {
             if (err) {
                 vscode.window.showErrorMessage(err.message);
             } else {
-                vscode.window.showInformationMessage("Template created");
+                vscode.window.showQuickPick(["Yes", "No"], { placeHolder: "Edit the new template?" }).then((choice) => {
+                    if (choice === "Yes") {
+                        vscode.workspace.openTextDocument(templateFile).then((doc) => {
+                            const editor = vscode.window.activeTextEditor;
+                            const column = editor.viewColumn;
+                            vscode.window.showTextDocument(doc, column);
+                        });
+                    }
+                });
             }
 
         });


### PR DESCRIPTION
After creating a template from the current file, the user will be prompted to edit the currently created template. If they choose "Yes" then the file will be opened in the active editor's column. If they choose "No" then nothing happens.

This allows someone to create a template from a file, and then edit it to remove parts that don't need to be in the template or add variables, etc.