### PR TITLE
Additional variables and improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
       "type": "object",
       "title": "VSCode File Templates Configuration",
       "properties": {
-        "file-templates.default.author": {
+        "fileTemplates.author": {
           "type": ["string", "null"],
           "default": null,
           "description": "Value to use to replace #{author} variable."
         },
-        "file-templates.default.company": {
+        "fileTemplates.company": {
           "type": ["string", "null"],
           "default": null,
           "description": "Value to use to replace #{company} variable."

--- a/package.json
+++ b/package.json
@@ -23,6 +23,22 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "VSCode File Templates Configuration",
+      "properties": {
+        "file-templates.default.author": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Value to use to replace #{author} variable."
+        },
+        "file-templates.default.company": {
+          "type": ["string", "null"],
+          "default": null,
+          "description": "Value to use to replace #{company} variable."
+        }
+      }
+    },
     "commands": [
       {
         "command": "extension.fileFromTemplate",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "tslint": "^3.13.0",
     "typescript": "^1.8.5",
     "vscode": "^0.11.0"
+  },
+  "dependencies": {
+    "moment": "^2.18.1"
   }
 }

--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -51,7 +51,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
 
         // ask for filename
         let inputOptions = <vscode.InputBoxOptions> {
-            prompt: "Please enter the desired filename",
+            prompt: "Please enter the desired file name",
             value: selection,
         };
 

--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -24,7 +24,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
     let targetFolder = args ? args.fsPath : vscode.workspace.rootPath;
 
     if (templates.length === 0) {
-        let optionGoToTemplates = <vscode.MessageItem> {
+        let optionGoToTemplates = <vscode.MessageItem>{
             title: "Open Templates Folder"
         };
 
@@ -51,7 +51,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
         }
 
         // ask for filename
-        let inputOptions = <vscode.InputBoxOptions> {
+        let inputOptions = <vscode.InputBoxOptions>{
             prompt: "Please enter the desired file name",
             value: selection,
         };
@@ -63,46 +63,68 @@ export function run(templatesManager: TemplatesManager, args: any) {
             const className = filename.replace(/\.[^/.]+$/, "");
             const resultsPromise = [];
 
-            let regexResult = /#{(\w+)}/g.exec(fileContents);
-            while (regexResult) {
-                const variableName = regexResult[1];
-                const regex = new RegExp(`#{${variableName}}`, "g");
+            let expression = /#{(\w+)}/g;
+
+            var matches;
+            var placeholders = [];
+            while (matches = expression.exec(fileContents)) {
+                if (placeholders.indexOf(matches[0]) != -1) {
+                    continue;
+                }
+                placeholders.push(matches[0]);
+            }
+
+            placeholders.forEach(function (placeholder) {
+                const variableName = /#{(\w+)}/.exec(placeholder)[1];
+                const search = new RegExp(placeholder, 'g')
 
                 switch (variableName) {
                     case "filename":
-                        fileContents = fileContents.replace(regex, className);
+                        fileContents = fileContents.replace(search, className);
                         break;
-
                     case "filepath":
                         let workspaceRoot = vscode.workspace.rootPath;
-                        fileContents = fileContents.replace(regex, targetFolder.replace(`${workspaceRoot}/`, ""));
+                        fileContents = fileContents.replace(search, targetFolder.replace(`${workspaceRoot}/`, ""));
                         break;
-
                     case "year":
-                        fileContents = fileContents.replace(regex, moment().format("YYYY"));
+                        fileContents = fileContents.replace(search, moment().format("YYYY"));
                         break;
-
                     case "date":
-                        fileContents = fileContents.replace(regex, moment().format("D MMM YYYY"));
+                        fileContents = fileContents.replace(search, moment().format("D MMM YYYY"));
                         break;
-
                     default:
                         if (workspaceSettings && workspaceSettings[variableName]) {
-                            fileContents = fileContents.replace(regex, workspaceSettings[variableName]);
+                            fileContents = fileContents.replace(search, workspaceSettings[variableName]);
                         } else {
-                            fileContents = fileContents.replace(regex, variableName.toUpperCase());
+                            let variableInput = <vscode.InputBoxOptions>{
+                                prompt: `Please enter the desired value for "${variableName}"`
+                            };
+                            let variablePromise = new Promise((resolve, reject) => {
+                                vscode.window.showInputBox(variableInput).then(value => {
+                                    let replacement;
+                                    if (!value) {
+                                        replacement = variableName.toUpperCase();
+                                    } else {
+                                        replacement = value;
+                                    }
+
+                                    fileContents = fileContents.replace(search, replacement);
+                                    resolve(fileContents);
+                                });
+                            });
+                            resultsPromise.push(variablePromise);
                         }
                         break;
                 }
+            });
 
-                regexResult = /#{(\w+)}/g.exec(fileContents);
-            }
-
-            fs.writeFile(path.join(targetFolder, filename), fileContents, function (err) {
-                if (err) {
-                    vscode.window.showErrorMessage(err.message);
-                }
-                vscode.window.showInformationMessage(filename + " created");
+            Promise.all(resultsPromise).then(() => {
+                fs.writeFile(path.join(targetFolder, filename), fileContents, function (err) {
+                    if (err) {
+                        vscode.window.showErrorMessage(err.message);
+                    }
+                    vscode.window.showInformationMessage(filename + " created");
+                });
             });
         });
     });

--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -24,7 +24,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
     let targetFolder = args ? args.fsPath : vscode.workspace.rootPath;
 
     if (templates.length === 0) {
-        let optionGoToTemplates = <vscode.MessageItem>{
+        let optionGoToTemplates = <vscode.MessageItem> {
             title: "Open Templates Folder"
         };
 
@@ -51,7 +51,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
         }
 
         // ask for filename
-        let inputOptions = <vscode.InputBoxOptions>{
+        let inputOptions = <vscode.InputBoxOptions> {
             prompt: "Please enter the desired file name",
             value: selection,
         };
@@ -65,18 +65,18 @@ export function run(templatesManager: TemplatesManager, args: any) {
 
             let expression = /#{(\w+)}/g;
 
-            var matches;
-            var placeholders = [];
-            while (matches = expression.exec(fileContents)) {
-                if (placeholders.indexOf(matches[0]) != -1) {
-                    continue;
+            let placeholders = [];
+            let matches = expression.exec(fileContents);
+            while (matches) {
+                if (placeholders.indexOf(matches[0]) === -1) {
+                    placeholders.push(matches[0]);
                 }
-                placeholders.push(matches[0]);
+                matches = expression.exec(fileContents);
             }
 
             placeholders.forEach(function (placeholder) {
                 const variableName = /#{(\w+)}/.exec(placeholder)[1];
-                const search = new RegExp(placeholder, 'g')
+                const search = new RegExp(placeholder, "g");
 
                 switch (variableName) {
                     case "filename":
@@ -96,7 +96,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
                         if (workspaceSettings && workspaceSettings[variableName]) {
                             fileContents = fileContents.replace(search, workspaceSettings[variableName]);
                         } else {
-                            let variableInput = <vscode.InputBoxOptions>{
+                            let variableInput = <vscode.InputBoxOptions> {
                                 prompt: `Please enter the desired value for "${variableName}"`
                             };
                             let variablePromise = new Promise((resolve, reject) => {

--- a/src/commands/fileFromTemplateCommand.ts
+++ b/src/commands/fileFromTemplateCommand.ts
@@ -57,7 +57,7 @@ export function run(templatesManager: TemplatesManager, args: any) {
         };
 
         vscode.window.showInputBox(inputOptions).then(filename => {
-            let workspaceSettings = vscode.workspace.getConfiguration("file-templates");
+            let workspaceSettings = vscode.workspace.getConfiguration("fileTemplates");
 
             let fileContents = templatesManager.getTemplate(selection);
             const className = filename.replace(/\.[^/.]+$/, "");
@@ -87,8 +87,8 @@ export function run(templatesManager: TemplatesManager, args: any) {
                         break;
 
                     default:
-                        if (workspaceSettings && workspaceSettings["default"] && workspaceSettings["default"][variableName]) {
-                            fileContents = fileContents.replace(regex, workspaceSettings["default"][variableName]);
+                        if (workspaceSettings && workspaceSettings[variableName]) {
+                            fileContents = fileContents.replace(regex, workspaceSettings[variableName]);
                         } else {
                             fileContents = fileContents.replace(regex, variableName.toUpperCase());
                         }

--- a/src/templatesManager.ts
+++ b/src/templatesManager.ts
@@ -24,7 +24,10 @@ export default class TemplatesManager {
         // @TODO make this async (use promises ???)
         let templateDir: string = this.getTemplatesDir();
         let templateFiles: string[] = fs.readdirSync(templateDir).map(function (item) {
-            return fs.statSync(path.join(templateDir, item)).isFile() ? item : null;
+            if (!/^\./.exec(item)) {
+                return fs.statSync(path.join(templateDir, item)).isFile() ? item : null;
+            }
+            return null;
         }).filter(function (filename) {
             return filename !== null;
         });


### PR DESCRIPTION
Hi there,

Found your plugin while looking for how to go about file template in VS Code. I've made the following changes in order to support our team's own usage.

- Added additional variables: `#{date}` (e.g. 1 Jan 2017), `#{year}`, `#{filepath}` (path of file relative to workspace root).
- Contributes configuration `fileTemplates.author` and `fileTemplates.company` so `#{author}` and `#{company}` can take their respective values per user/workspace settings (.vscode/settings.json).
- For other variable names, if the user did not provide a value in the input box, replace the variable with the uppercased version of the variable name, but still resolve the promise so it's not stuck.
- Hide files with names starting with `.` in the template selection prompt.
- Also, I noticed that if you put multiple variables in the same line in the template, some will fail to be replaced. So I've made some changes to fix that.

Hope you'll consider merging this back. Also, keep up the good work!
